### PR TITLE
update blocksCovered non-archive node endpoints

### DIFF
--- a/substrate/crawler.js
+++ b/substrate/crawler.js
@@ -1821,7 +1821,6 @@ create table talismanEndpoint (
                 [row] = await tableChain.row(paraTool.blockNumberToHex(bn)).get({
                     filter
                 });
-                console.log(row);
             }
         }
         if (row == null) {
@@ -1975,8 +1974,7 @@ create table talismanEndpoint (
                 this.batchedSQL.push(sql);
                 // mark that the PREVIOUS hour is ready for indexing, since this block is FINALIZED, so that continuously running "indexChain" job can index the newly finalized hour
                 this.markFinalizedReadyForIndexing(chainID, blockTS);
-                let sql2 = `update chain set blocksFinalized = '${bn}', lastFinalizedDT = Now() where chainID = '${chainID}'`;
-
+                let sql2 = `insert into chain ( chainID, blocksCovered, blocksFinalized, lastFinalizedDT ) values ( '${chainID}', '${bn}', '${bn}', Now() ) on duplicate key update blocksFinalized = values(blocksFinalized), lastFinalizedDT = values(lastFinalizedDT), blocksCovered = IF( blocksCovered < values(blocksFinalized), values(blocksFinalized), blocksCovered )`
                 this.batchedSQL.push(sql2);
                 if (bn % 5000 == indexUpdateInterval) {
                     // every 5000 blocks, push 24 hours of onto indexlog from blocklog

--- a/views/footer.ejs
+++ b/views/footer.ejs
@@ -8,9 +8,11 @@
 
 <div>
 <span>
-<a href="https://docs.google.com/forms/d/1EAiEdPY3OekTukNnfuwTm9SSuLHrMYi8zC3QuzUZ7WU/edit" class="btn btn-link text-capitalize" id="reportIssue"><i class="fa-regular fa-comment"></i> Report Data Issue / Bugs</a>
-
 <a href="https://matrix.to/#/#polkaholic:matrix.org" class="btn btn-link text-capitalize" id="matrix"><i class="fa-regular fa-comments"></i> Chat with Us</a>
+
+<a href="https://github.com/colorfulnotion/polkaholic/issues" class="btn btn-link text-capitalize" id="reportIssue"><i class="fa-regular fa-comment"></i> Report Data Issue / Bugs</a>
+
+<a href="https://github.com/colorfulnotion/polkaholic" class="btn btn-link text-capitalize" id="matrix"><i class="fa-brands fa-github"></i> Github</a>
 </span>
 <span style='float: right'>
 <a href="https://polkaholic.hyperping.io/" class="btn btn-link text-capitalize" id="webuptime"><i class="fa-regular fa-chart-bar"></i> Polkaholic Uptime</a>


### PR DESCRIPTION
Since some public ws endpoints don't have "subscribeStorage" support (which provide trace coverage), we need to update chain.blocksCovered with blocksFinalized.

Also:
* updated footer with github links to this repo