### PR TITLE
write addressBalanceRequest on tip when traces missing

### DIFF
--- a/substrate/chains/chainparser.js
+++ b/substrate/chains/chainparser.js
@@ -2329,6 +2329,16 @@ module.exports = class ChainParser {
         }
     }
 
+
+    reapingFilter(palletMethod) {
+        //let palletMethod = `${rewardEvent.section}(${rewardEvent.method})`
+        if (palletMethod == "balances(DustLost)" || palletMethod == "tokens:dustLost") {
+            return true
+        } else {
+            return false;
+        }
+    }
+
     proxyFilter(palletMethod) {
         //let palletMethod = `${rewardEvent.section}(${rewardEvent.method})`
         if (palletMethod == "proxy(ProxyAdded)" || palletMethod == "proxy(ProxyRemoved)" || palletMethod == "proxy(AnonymousCreated)") {

--- a/substrate/crawler.js
+++ b/substrate/crawler.js
@@ -1921,7 +1921,7 @@ create table talismanEndpoint (
                     if (evmReceipts) crawlReceiptsEVM = 0;
                     if (evmTrace) crawlTraceEVM = 0;
                 }
-                let r = await this.index_chain_block_row(rRow, false, false); // signedBlock is false, write_bq_log = false
+                let r = await this.index_chain_block_row(rRow, false, false, false, true); // signedBlock is false, write_bq_log = false, isTip = TRUE
                 blockStats = r.blockStats;
                 // IMMEDIATELY flush all address feed + hashes (txs + blockhashes)
                 await this.flush(block.blockTS, bn, false, isTip); //ts, bn, isFullPeriod, isTip

--- a/substrate/schema/cbt.sh
+++ b/substrate/schema/cbt.sh
@@ -16,5 +16,5 @@ cbt createtable  apikeys  "families=rate:maxversions=1,n:maxversions=1"
 cbt setgcpolicy  apikeys  rate maxage=3d or maxversions=1
 
 # chain tables follow the following schema; but evm chain tables have 4 additional columns: blockrawevm, feedevm, receiptsevm, traceevm
-cbt createtable  chain0      "families=blockraw:maxversions=1,trace:maxversions=1,finalized:maxversions=1,n:maxversions=1,events:maxversions=1,feed:maxversions=1"
-cbt createtable  chain2004   "families=blockraw:maxversions=1,trace:maxversions=1,finalized:maxversions=1,n:maxversions=1,events:maxversions=1,feed:maxversions=1,blockrawevm:maxversions=1,feedevm:maxversions=1,receiptsevm:maxversions=1,traceevm:maxversions=1"
+cbt createtable  chain0      "families=blockraw:maxversions=1,autotrace=maxversions=1,trace:maxversions=1,finalized:maxversions=1,n:maxversions=1,events:maxversions=1,feed:maxversions=1"
+cbt createtable  chain2004   "families=blockraw:maxversions=1,autotrace=maxversions=1,trace:maxversions=1,finalized:maxversions=1,n:maxversions=1,events:maxversions=1,feed:maxversions=1,blockrawevm:maxversions=1,feedevm:maxversions=1,receiptsevm:maxversions=1,traceevm:maxversions=1"


### PR DESCRIPTION
Because traces go missing (systematically on new chains, and with any subscribe storage gap),
we need to have a stop gap measure for getting balances without the traces.

So, when isTip = true + when traces are KNOWN to be missing, we write address/bn/request=1 to address${chainID} table.
TODO: crawlAddressBalance process which will treat all request=1 cases; query updates