### PR TITLE
Use Extrinsic's watermark for outgoing ump/hrmp

### DIFF
--- a/substrate/chains/chainparser.js
+++ b/substrate/chains/chainparser.js
@@ -348,7 +348,7 @@ module.exports = class ChainParser {
                         msgHash: msgHash,
                         msgHex: data,
                         msgStr: JSON.stringify(dmpMsg),
-                        sentAt: dmp.sentAt,
+                        sentAt: dmp.sentAt, //dmp is guranteed to be correct
                         chainID: indexer.chainID,
                         chainIDDest: chainIDDest,
                         relayChain: relayChain,
@@ -410,7 +410,8 @@ module.exports = class ChainParser {
                         msgHash: msgHash,
                         msgHex: data,
                         msgStr: JSON.stringify(umpMsg),
-                        sentAt: this.parserWatermark, //this is potentially off by 2-4 blocks
+                        //sentAt: this.parserWatermark, //this is potentially off by 2-4 blocks
+                        sentAt: 0,
                         chainID: indexer.chainID,
                         chainIDDest: (relayChain == 'polkadot') ? 0 : 2,
                         relayChain: relayChain,
@@ -469,7 +470,8 @@ module.exports = class ChainParser {
                         msgHash: msgHash,
                         msgHex: data,
                         msgStr: JSON.stringify(hrmpMsg),
-                        sentAt: this.parserWatermark, //this is potentially off by 2-4 blocks
+                        //sentAt: this.parserWatermark, //this is potentially off by 2-4 blocks
+                        sentAt: 0,
                         chainID: indexer.chainID,
                         chainIDDest: hrmp.recipient + paraIDExtra,
                         relayChain: relayChain,
@@ -840,6 +842,8 @@ module.exports = class ChainParser {
                   let hrmpWatermark = data.validationData.relayParentNumber
                   this.parserWatermark = hrmpWatermark
                   if (this.debugLevel >= paraTool.debugVerbose) console.log(`[${this.parserBlockNumber}] Update hrmpWatermark from extrinsic: ${hrmpWatermark}`)
+                  //TODO: update all outgoing trace msg with this hrmp
+                  indexer.fixOutgoingUnknownSentAt(hrmpWatermark);
                 } catch (err1){
                   console.log(`unable to find watermarkBN`, err1.toString())
                 }

--- a/substrate/chains/chainparser.js
+++ b/substrate/chains/chainparser.js
@@ -2299,7 +2299,7 @@ module.exports = class ChainParser {
                     let assets = a.assets;
                     let feeAssetIndex = a.fee_asset_item
                     if (assets.v0 !== undefined && Array.isArray(assets.v0) && assets.v0.length > 0) {
-                        console.log(`[${extrinsic.extrinsicHash}] section_method=${section_method} v0 case`, JSON.stringify(a, null, 2))
+                        if (this.debugLevel >= paraTool.debugVerbose) console.log(`[${extrinsic.extrinsicHash}] section_method=${section_method} v0 case`, JSON.stringify(a, null, 2))
                         let assetsv0 = assets.v0
                         let transferIndex = 0
                         for (const asset of assetsv0) {

--- a/substrate/indexer.js
+++ b/substrate/indexer.js
@@ -1108,6 +1108,7 @@ module.exports = class Indexer extends AssetManager {
       for (const xcmKey of xcmKeys){
         let xcmMsg = this.xcmmsgSentAtUnknownMap[xcmKey]
         xcmMsg.sentAt = sentAt
+        if (this.debugLevel >= paraTool.debugInfo) console.log(`Adding sentAt ${sentAt} [${xcmKey}]`)
         this.updateXCMMsg(xcmMsg, true)
       }
       this.xcmmsgSentAtUnknownMap = {}
@@ -1117,13 +1118,12 @@ module.exports = class Indexer extends AssetManager {
     updateXCMMsg(xcmMsg, overwrite = false) {
         let direction = (xcmMsg.isIncoming) ? 'i' : 'o'
         if (direction == 'o' && xcmMsg.msgType != 'dmp' && !overwrite){
-          //sentAt is technically unknown for ..
-          let xcmKey = `${xcmMsg.msgHash}-${xcmMsg.msgType}-${direction}`
-          console.log(`updateXCMMsg [${xcmKey}] sentAt unknown`)
-          this.xcmmsgSentAtUnknownMap[xcmKey] = xcmMsg
+            //sentAt is theoretically unknown for ump/hrmp..
+            let xcmKey = `${xcmMsg.msgHash}-${xcmMsg.msgType}-${direction}`
+            if (this.debugLevel >= paraTool.debugVerbose) console.log(`xcmmsg SentAt Unknown [${xcmKey}]`)
+            this.xcmmsgSentAtUnknownMap[xcmKey] = xcmMsg
         }else{
           let xcmKey = `${xcmMsg.msgHash}-${xcmMsg.msgType}-${xcmMsg.sentAt}-${direction}`
-          if (overwrite) console.log(`updateXCMMsg sentAt=${xcmMsg.sentAt}, ${xcmKey}`)
           if (this.xcmTrailingKeyMap[xcmKey] == undefined) {
               this.xcmTrailingKeyMap[xcmKey] = {
                   blockNumber: xcmMsg.blockNumber,
@@ -2845,7 +2845,7 @@ order by msgHash, diffSentAt, diffTS`
     }
 
     // find the msgHash given {BN, recipient}
-    getMsgHashCandidate(targetBN, destAddress = false) {
+    getMsgHashCandidate(targetBN, destAddress = false, extrinsicID = false, extrinsicHash = false) {
         if (!destAddress) {
             if (this.debugLevel >= paraTool.debugErrorOnly) console.log(`getMsgHashCandidate [${targetBN}], dest MISSING`)
             return false
@@ -2867,6 +2867,10 @@ order by msgHash, diffSentAt, diffTS`
                 //criteria: firstSeen at the block when xcmtransfer is found + recipient match
                 //this should give 99% coverage? let's return on first hit for now
                 if (this.debugLevel >= paraTool.debugInfo) console.log(`getMsgHashCandidate [${targetBN}, dest=${destAddress}] FOUND candidate=${msgHash}`)
+                if (this.xcmmsgMap[tk] != undefined){
+                   this.xcmmsgMap[tk].extrinsicID = extrinsicID
+                   this.xcmmsgMap[tk].extrinsicHash = extrinsicHash
+                }
                 return msgHash
             }
         }
@@ -2895,7 +2899,7 @@ order by msgHash, diffSentAt, diffTS`
             let rows = this.recentXcmMsgs
             if (this.debugLevel >= paraTool.debugTracing) console.log(`dump_xcm_messages rowsLen=${rows.length}`, rows)
             let i = 0;
-            let vals = ["chainIDDest", "chainID", "msgType", "msgHex", "msgStr", "blockTS", "blockNumber", "relayChain", "version", "path"];
+            let vals = ["chainIDDest", "chainID", "msgType", "msgHex", "msgStr", "blockTS", "blockNumber", "relayChain", "version", "path", "extrinsicID", "extrinsicHash"];
             for (i = 0; i < rows.length; i += 10000) {
                 let j = i + 10000;
                 if (j > rows.length) j = rows.length;
@@ -4147,7 +4151,7 @@ order by msgHash, diffSentAt, diffTS`
                         if (this.debugLevel >= paraTool.debugInfo && !finalized) console.log(`safeXcmTip [${rExtrinsic.extrinsicID}] [${rExtrinsic.section}:${rExtrinsic.method}] xcmCnt=${rExtrinsic.xcms.length}`)
                         for (const xcmtransfer of rExtrinsic.xcms) {
                             //Look up msgHash
-                            let msgHashCandidate = this.getMsgHashCandidate(xcmtransfer.blockNumber, xcmtransfer.destAddress)
+                            let msgHashCandidate = this.getMsgHashCandidate(xcmtransfer.blockNumber, xcmtransfer.destAddress, rExtrinsic.extrinsicID, rExtrinsic.extrinsicHash)
                             if (msgHashCandidate) xcmtransfer.msgHash = msgHashCandidate
                             this.stat.addressRows.xcmsend++;
                             this.updateAddressExtrinsicStorage(fromAddress, extrinsicID, extrinsicHash, "feedxcm", xcmtransfer, blockTS, block.finalized);
@@ -5365,8 +5369,12 @@ from assetholder${chainID} as assetholder, asset where assetholder.asset = asset
                 let mpKey = this.xcmTrailingKeyMap[xcmKey]
                 if (mpKey != undefined && mpKey.isFresh) {
                     let mp = this.xcmmsgMap[xcmKey]
+                    let direction = (mp.isIncoming) ? 'incoming' : 'outgoing'
+                    if (xcmKeys.length > 0 && this.debugLevel >= paraTool.debugInfo) console.log(`xcmMessages ${direction}`, mp)
+                    let extrinsicID = (mp.extrinsicID != undefined)? `'${mp.extrinsicID}'` : 'NULL'
+                    let extrinsicHash = (mp.extrinsicHash != undefined)? `'${mp.extrinsicHash}'` : 'NULL'
                     //["msgHash", "incoming", "chainIDDest", "chainID", "msgType", "msgHex", "msgStr", "blockTS", "blockNumber", "sentAt", "relayChain", "version", "path"];
-                    let s = `('${mp.msgHash}', '${mp.isIncoming}', '${mp.sentAt}', '${mp.chainIDDest}', '${mp.chainID}', '${mp.msgType}', '${mp.msgHex}', ${mysql.escape(mp.msgStr)}, '${mp.blockTS}', '${mp.blockNumber}', '${mp.relayChain}', '${mp.version}', '${mp.path}')`
+                    let s = `('${mp.msgHash}', '${mp.isIncoming}', '${mp.sentAt}', '${mp.chainIDDest}', '${mp.chainID}', '${mp.msgType}', '${mp.msgHex}', ${mysql.escape(mp.msgStr)}, '${mp.blockTS}', '${mp.blockNumber}', '${mp.relayChain}', '${mp.version}', '${mp.path}', ${extrinsicID}, ${extrinsicHash})`
                     recentXcmMsgs.push(s);
                     if (xcmKeys.length > 0 && this.debugLevel >= paraTool.debugInfo) console.log(`[${blockNumber}] add ${xcmKey}`, s)
                     this.xcmTrailingKeyMap[xcmKey].isFresh = false // mark the record as processed


### PR DESCRIPTION
* Also write extrinsicID, extrinsicHash <-> xcmmessages map whenever available
* Q: perhaps we should change the primary keys to {incoming, msgHash, blockTS} or  {incoming, msgHash, blockNumber}?