### PR TITLE
xcmMatch Improvement 

### DIFF
--- a/substrate/assetManager.js
+++ b/substrate/assetManager.js
@@ -1285,7 +1285,7 @@ module.exports = class AssetManager extends PolkaholicDB {
                         await this.update_batchedSQL();
                     }
                 } else {
-                    console.log(`NativeAssetChain NOT FOUND [${xcm.extrinsicHash}] targetAsset=${targetAsset}, targetChainID=${targetChainID}, asset=${asset}, rawAsset=${rawAsset}`)
+                    console.log(`NativeAssetChain NOT FOUND [${xcm.extrinsicHash}] nativeAsset=${nativeAsset}, nativeChainID=${nativeChainID}, asset=${asset}, rawAsset=${rawAsset}`)
                 }
             } else {
                 console.log(`XCM Asset Not found chainID=${chainID}, asset=${asset}, rawAsset=${rawAsset}`)

--- a/substrate/indexer.js
+++ b/substrate/indexer.js
@@ -1221,11 +1221,14 @@ module.exports = class Indexer extends AssetManager {
     updateXCMTransferDestCandidate(candidate, caller = false) {
         //potentially add sentAt here, but it's 2-4
         let eventID = candidate.eventID
-        if (eventID != undefined) {
-            this.xcmtransferdestcandidate[eventID] = candidate
-        }
-        if (caller) {
-            if (this.debugLevel >= paraTool.debugInfo) console.log(`${caller} candidate`, this.xcmtransferdestcandidate[eventID]);
+        let k = `${candidate.msgHash}-${candidate.amountReceived}` // it's nearly impossible to have collision even dropping the asset
+        if (this.xcmtransferdestcandidate[k] == undefined){
+            this.xcmtransferdestcandidate[k] = candidate
+            if (caller) {
+                if (this.debugLevel >= paraTool.debugInfo) console.log(`${caller} candidate`, this.xcmtransferdestcandidate[k]);
+            }
+        }else{
+            if (this.debugLevel >= paraTool.debugInfo) console.log(`${caller} skip duplicate candidate ${eventID}`, );
         }
     }
 

--- a/substrate/xcmmanager.js
+++ b/substrate/xcmmanager.js
@@ -43,7 +43,7 @@ module.exports = class XCMManager extends AssetManager {
         d.chainIDDest = xcmtransfer.chainIDDest and
         ((d.asset = xcmtransfer.asset) or (d.nativeAssetChain = xcmtransfer.nativeAssetChain and d.nativeAssetChain is not null)) and
         xcmtransfer.sourceTS >= ${startTS} and
-
+        xcmtransfer.xcmInteriorKey = d.xcmInteriorKey and
         d.destTS >= ${startTS} and
         xcmtransfer.matched = 0 and
         d.matched = 0 and
@@ -103,23 +103,6 @@ order by chainID, extrinsicHash, diffTS`
                             console.log(`NativeAssetChain NOT FOUND [${m.extrinsicHash}] nativeAsset=${nativeAsset}, nativeChainID=${nativeChainID}, asset=${asset}, rawAsset=${rawAsset}`)
                         }
                     }
-
-                    /*
-                    let decimals = this.getAssetDecimal(d.asset, d.chainID)
-                    if (decimals === false) {
-                        decimals = this.getAssetDecimal(d.asset, d.chainIDDest)
-                    }
-                    if (decimals !== false) {
-                        let [_, priceUSDsourceTS, __] = await this.computeUSD(1.0, d.asset, d.chainID, d.sourceTS);
-                        if (priceUSDsourceTS > 0) {
-                            priceUSD = priceUSDsourceTS;
-                            let amountSent = parseFloat(d.amountSent) / 10 ** decimals;
-                            let amountReceived = parseFloat(d.amountReceived) / 10 ** decimals;
-                            amountSentUSD = (amountSent > 0) ? priceUSD * amountSent : 0;
-                            amountReceivedUSD = (amountReceived > 0) ? priceUSD * amountReceived : 0;
-                        }
-                    }
-                    */
                     let sql = `update xcmtransfer
             set blockNumberDest = ${d.blockNumberDest},
                 destTS = ${d.destTS},
@@ -131,7 +114,7 @@ order by chainID, extrinsicHash, diffTS`
                 matchedExtrinsicID = '${d.destExtrinsicID}',
                 matchedEventID = '${d.eventID}'
             where extrinsicHash = '${d.extrinsicHash}' and transferIndex = '${d.transferIndex}'`
-                    console.log(sql);
+                    //console.log(sql);
                     this.batchedSQL.push(sql);
                     matches++;
                     // (a) with extrinsicID, we get both the fee (rat << 1) ANDthe transferred item for when one is isFeeItem=0 and another is isFeeItem=1; ... otherwise we get (b) with just the eventID

--- a/substrate/xcmmanager.js
+++ b/substrate/xcmmanager.js
@@ -760,7 +760,7 @@ order by msgHash, diffSentAt, diffTS`
         console.log(sql2);
         await this.update_batchedSQL();
 
-	// update 
+	// update
         // ((d.asset = xcmmessages.asset) or (d.nativeAssetChain = xcmmessages.nativeAssetChain and d.nativeAssetChain is not null)) and
         // No way to get "sentAt" in xcmtransferdestcandidate to tighten this?
         let fld = (this.getCurrentTS() % 2 == 0) ? "" : "2"
@@ -775,20 +775,21 @@ order by msgHash, diffSentAt, diffTS`
           xcmmessages.extrinsicID,
           xcmmessages.blockTS,
           xcmmessages.beneficiaries${fld},
-          d.eventID, d.asset, d.rawAsset, d.nativeAssetChain, d.amountReceived, d.blockNumberDest, d.destTS
+          d.eventID, d.asset, d.rawAsset, d.nativeAssetChain, d.amountReceived, d.blockNumberDest, d.destTS, d.msgHash as candidateMsgHash
         from xcmmessages, xcmtransferdestcandidate as d
  where  d.fromAddress = xcmmessages.beneficiaries and
         d.chainIDDest = xcmmessages.chainIDDest and
+        d.msgHash = xcmmessages.msgHash and
         d.sentAt - xcmmessages.sentAt >= 0 and d.sentAt - xcmmessages.sentAt <= 4 and
         xcmmessages.blockTS >= ${startTS} and
-        d.addDT is not null and 
+        d.addDT is not null and
         d.destTS >= ${startTS} and
         d.destTS - xcmmessages.blockTS >= 0 and
         d.destTS - xcmmessages.blockTS < ${lookbackSeconds} and
         xcmmessages.assetsReceived is Null and
         length(xcmmessages.extrinsicID) > 0  ${endWhere}
 order by chainID, extrinsicHash, eventID, diffTS`;
-	// unmatch with: 
+	// unmatch with:
 	//  update xcmmessages set assetsReceived = null, amountReceivedUSD = 0 where sourceTS >= unix_timestamp("2022-07-01") and sourceTS < unix_timestamp("2022-08-14 00:00")
 	//  update xcmtransfer set assetsReceived = null, amountReceivedUSD2 = 0 where sourceTS >= unix_timestamp("2022-07-01") and sourceTS < unix_timestamp("2022-08-14 00:00")
 	// rematch with: ./xcmmatch 45


### PR DESCRIPTION
* remove duplicates dest candidate events
* match xcmtransfer and xcmDestCandidate on {amount + xcmInteriorkey}
* require {incoming.chainIDDest, outgoing.chainIDDest} + {parent.chainIDDest, child.chainID} matching
* Use priceTS(destTS, fallback to sourceTS) for USD valuation
