### PR TITLE
exponential backoff on attempted

### DIFF
--- a/substrate/query.js
+++ b/substrate/query.js
@@ -5199,6 +5199,7 @@ module.exports = class Query extends AssetManager {
     mergeEventDataAndDataType(data, dataType, decorate = true, decorateExtra = ["data", "address", "usd", "related"]) {
         let [decorateData, decorateAddr, decorateUSD, decorateRelated] = this.getDecorateOption(decorateExtra)
         let dd = []
+        if (!data || !data.length) return dd;
         for (var i = 0; i < data.length; i++) {
             let d = data[i]
             let x = {

--- a/substrate/substrate-etl
+++ b/substrate/substrate-etl
@@ -82,6 +82,8 @@ async function main() {
         .option('-r, --relayChain <relayChain>', 'Relay chain', null)
         .option('-p, --paraID <paraID>', 'Para ID', myParseInt)
         .option('-l, --logDT <logDT>', 'Date', null)
+        .option('--endDT <endDT>', 'Date', null)
+
         .option('-d, --dry', `dry run the cmd without updating`, false)
         .action(async (opt) => {
             let substrateetl = new SubstrateETL();
@@ -90,7 +92,17 @@ async function main() {
             let logDT = opt.logDT;
             let dry = opt.dry;
             if (logDT && paraID && relayChain) {
-                await substrateetl.dump_accountmetrics(relayChain, paraID, logDT, dry);
+                let endDT = opt.logDT && opt.endDT ? opt.endDT : null;
+                if (endDT) {
+                    let logTS = paraTool.logDT_hr_to_ts(logDT, 0);
+                    let endTS = paraTool.logDT_hr_to_ts(endDT, 0);
+                    for (let ts = logTS; ts <= endTS; ts += 86400) {
+                        let [dt, hr] = paraTool.ts_to_logDT_hr(ts);
+                        await substrateetl.dump_accountmetrics(relayChain, paraID, dt, dry);
+                    }
+                } else {
+                    await substrateetl.dump_accountmetrics(relayChain, paraID, logDT, dry);
+                }
                 process.exit(0);
             }
             let tally = 0;
@@ -143,19 +155,34 @@ async function main() {
         .description(`Update Balances for some chain`)
         .option('-c, --chainID <chainID>', 'ChainID to update balances', myParseInt)
         .option('-l, --logDT <logDT>', 'Date to update', null)
+        .option('--endDT <endDT>', 'Date to update', null)
         .action(async (opt) => {
-            chainID = opt.chainID ? opt.chainID : null;
-            logDT = opt.logDT ? opt.logDT : null;
+            let chainID = opt.chainID ? opt.chainID : null;
+            let logDT = opt.logDT ? opt.logDT : null;
+            let endDT = opt.logDT && opt.endDT ? opt.endDT : null;
 
-            if (chainID >= 0 && logDT) {
-                var manager = new SubstrateETL();
-                let done = false;
-                let startTS = manager.getCurrentTS();
-                do {
-                    console.log("GO!")
-                    done = await manager.update_address_balances_logDT(chainID, logDT, startTS);
-                } while (!done)
-                process.exit(0);
+            if (chainID >= 0) {
+                if (endDT && logDT) {
+                    var manager = new SubstrateETL();
+                    let done = false;
+                    let logTS = paraTool.logDT_hr_to_ts(logDT, 0);
+                    let endTS = paraTool.logDT_hr_to_ts(endDT, 0);
+                    for (let ts = logTS; ts <= endTS; ts += 86400) {
+                        let startTS = manager.getCurrentTS();
+                        let [dt, hr] = paraTool.ts_to_logDT_hr(ts);
+                        await manager.update_address_balances_logDT(chainID, dt, startTS);
+                    }
+                    process.exit(0);
+                } else if (logDT) {
+                    var manager = new SubstrateETL();
+                    let done = false;
+                    let startTS = manager.getCurrentTS();
+                    do {
+                        done = await manager.update_address_balances_logDT(chainID, logDT, startTS);
+                        await manager.sleep(5000);
+                    } while (!done)
+                    process.exit(0);
+                }
             } else {
                 while (1) {
                     var manager = new SubstrateETL();
@@ -216,7 +243,6 @@ async function main() {
         .action(async (relayChain, opt) => {
             var substrateetl = new SubstrateETL();
             let [weekagoDT, _] = paraTool.ts_to_logDT_hr(substrateetl.getCurrentTS() - 86400 * 7);
-            weekagoDT = "2022-08-01" // temporary
             let logDT = opt.logDT ? opt.logDT : weekagoDT;
             await substrateetl.dump_xcm_range(relayChain, logDT);
             await substrateetl.update_xcm_summary(relayChain, logDT);

--- a/substrate/xcmCleaner.js
+++ b/substrate/xcmCleaner.js
@@ -992,9 +992,9 @@ if a jump in balance is found in those N minutes, mark the blockNumber in ${chai
         return 0;
     }
 
-    async bulk_generate_XCMInfo(chainIDDest = null, lookbackDays = 7, limit = 1000) {
+    async bulk_generate_XCMInfo(chainIDDest = null, lookbackDays = 16, limit = 1000) {
         let w = chainIDDest ? `and chainIDDest = ${chainIDDest} ` : "";
-        let sql = `select extrinsicHash, xcmIndex, transferIndex, sourceTS, extrinsicID from xcmtransfer where chainIDDest >=0 and chainIDDest < 40000 and destStatus = -1 and sourceTS > UNIX_TIMESTAMP(date_sub(Now(), interval ${lookbackDays} DAY)) and sourceTS < UNIX_TIMESTAMP(Date_sub(Now(), interval 2 MINUTE)) and matchAttempts <= 2 and symbol is not null and matchAttemptDT < date_sub(Now(), interval 2 minute)  ${w} order by matchAttempts asc, sourceTS desc limit ${limit}`;
+        let sql = `select extrinsicHash, xcmIndex, transferIndex, sourceTS, extrinsicID from xcmtransfer where chainIDDest >=0 and chainIDDest < 40000 and destStatus = -1 and sourceTS > UNIX_TIMESTAMP("2022-05-05") and  sourceTS < UNIX_TIMESTAMP(Date_sub(Now(), interval 2 MINUTE)) and ( matchAttemptDT is null or matchAttemptDT < date_sub(Now(), INTERVAL POW(3, matchAttempts) MINUTE) ) and symbol is not null  and chainID in ( select chainID from chain where crawling = 1 ) and chainIDDest in ( select chainID from chain where crawling = 1 )  ${w}  order by matchAttempts asc, sourceTS desc limit ${limit}`;
         console.log(sql);
         let extrinsics = await this.pool.query(sql);
         let extrinsic = {};

--- a/substrate/xcmindexer
+++ b/substrate/xcmindexer
@@ -113,6 +113,7 @@ async function main() {
                 await manager.generate_extrinsic_XCMInfo(extrinsicHash, transferIndex, xcmIndex);
                 process.exit(0);
             } else if (opt.chainID != undefined) {
+                let chainID = opt.chainID;
                 let lookbackDays = opt.lookbackDays;
                 await manager.bulk_generate_XCMInfo(chainID, lookbackDays, 1000);
                 process.exit(0);


### PR DESCRIPTION
Instead of thresholding with the ad hoc attempted <= 2/3/5/10/20 solution
* block${chainID}.attemptedDT 
* indexlog.lastAttemptStartDT  (exists already)
* xcmtransfers.matchAttemptDT  (exists already)
* blocklog.loadAttemptDT ( add )
This uses a systemic "exponential backoff" approach to attack things again later
* attemptedDT is Null or attemptedDT < date_sub(Now(), interval POW(3, attempted) MINUTE)
where if you fail on the 3rd attempt on the 27 minute mark, you'll try again
4: 81 mins = 1.35 hrs 
5: 243 mins = 4 hrs
6: 729 mins = .5 day
7: 2187 mins = 1.5 days
8: 6561 mins = 4.5 days
9: 19683 mins = 13 days
10: 41 days
11: 123 days
So, if some automatic process is filling in data for today or yesterday, we can be assured that the 7th or 8th attempt will cover the problem within the week reliably, and we can check for continual failures for anything that is on its 9th or 10th attempt