### PR TITLE
Xcmv3 Coverage

### DIFF
--- a/substrate/chains/chainparser.js
+++ b/substrate/chains/chainparser.js
@@ -3123,6 +3123,17 @@ module.exports = class ChainParser {
         return destAddress
     }
 
+    processPolkadotXcmV3MsgCandidates(extrinsic){
+        let xcmMsgHashEvents = extrinsic.events.filter((ev) => {
+            return this.xcmMsgFilter(`${ev.section}(${ev.method})`);
+        })
+        let xcmMsgHashCandidates = []
+        for (const msgEvent of xcmMsgHashEvents){
+            xcmMsgHashCandidates.push(msgEvent.data[0])
+        }
+        return xcmMsgHashCandidates
+    }
+
     processOutgoingPolkadotXcm(indexer, extrinsic, feed, fromAddress, section_method, args) {
         let chainID = indexer.chainID
         if (extrinsic.xcmIndex == undefined) {
@@ -3131,6 +3142,8 @@ module.exports = class ChainParser {
             extrinsic.xcmIndex += 1
         }
         let outgoingXcmPallet = []
+        let xcmMsgHashCandidates = this.processPolkadotXcmV3MsgCandidates(extrinsic)
+        console.log(`xcmMsgHashCandidates`, xcmMsgHashCandidates)
         try {
             //let module_section = extrinsic.section;
             //let module_method = extrinsic.method;
@@ -3154,7 +3167,7 @@ module.exports = class ChainParser {
                 //let a = extrinsic.params;
                 let a = args
                 let assetAndAmountSents = [];
-
+                console.log(`${extrinsic.extrinsicID} arg`, a)
                 // !!!! beneficiary processing + dest processing MUST happen before asset
                 // beneficiary processing -- TODO: check that fromAddress is in beneficiary
                 if (a.beneficiary !== undefined) {
@@ -3186,12 +3199,29 @@ module.exports = class ChainParser {
                         } else {
                             if (this.debugLevel >= paraTool.debugErrorOnly) console.log(`beneficiary.v1 unknown case`, beneficiary.v1)
                         }
+                    } else if (beneficiary.v2 !== undefined) {
+                        // xcmV3 here
+                        console.log(`xcmV3 beneficiary.v2 case`, JSON.stringify(beneficiary.v2, null, 2))
+                        console.log("beneficiary v2=", JSON.stringify(a.beneficiary.v2));
+                        if (beneficiary.v2.interior !== undefined) {
+                            let beneficiaryV2Interior = beneficiary.v2.interior;
+                            // dest for relaychain
+                            if (beneficiaryV2Interior.x1 !== undefined) {
+                                [paraIDDest, chainIDDest, destAddress] = this.processX1(beneficiaryV2Interior.x1, relayChain)
+                            } else if (beneficiaryV2Interior.x2 !== undefined) {
+                                [paraIDDest, chainIDDest, destAddress] = this.processX2(beneficiaryV2Interior.x2, relayChain)
+                            } else {
+                                if (this.debugLevel >= paraTool.debugErrorOnly) console.log(`beneficiary.v2.interior unknown case`, beneficiaryV2Interior)
+                            }
+                        } else {
+                            if (this.debugLevel >= paraTool.debugErrorOnly) console.log(`beneficiary.v2 unknown case`, beneficiary.v2)
+                        }
                     } else if (beneficiary.x1 !== undefined) {
                         [paraIDDest, chainIDDest, destAddress] = this.processX1(beneficiary.x1, relayChain)
                     } else if (beneficiary.x2 !== undefined) {
                         [paraIDDest, chainIDDest, destAddress] = this.processX2(beneficiary.x2, relayChain)
                     } else {
-                        //if (this.debugLevel >= paraTool.debugErrorOnly) console.log(`[${extrinsic.extrinsicHash}] section_method=${section_method} Unknown beneficiary`, beneficiary)
+                        if (this.debugLevel >= paraTool.debugErrorOnly) console.log(`[${extrinsic.extrinsicHash}] section_method=${section_method} Unknown beneficiary`, beneficiary)
                     }
                 }
                 // dest processing
@@ -3234,6 +3264,23 @@ module.exports = class ChainParser {
                         chainIDDest = paraTool.getChainIDFromParaIDAndRelayChain(0, relayChain)
                     } else {
                         //if (this.debugLevel >= paraTool.debugErrorOnly) console.log("dest v1 int unk = ", JSON.stringify(dest.v1.interior));
+                        chainIDDest = false
+                    }
+                } else if ((dest.v2 !== undefined) && (dest.v2.interior !== undefined)){
+                    // xcmV3 here
+                    if (this.debugLevel >= paraTool.debugErrorOnly) console.log("xcmV3 dest v2 int unk = ", JSON.stringify(dest.v2.interior));
+                    let destV2Interior = dest.v2.interior
+                    if (destV2Interior.x1 !== undefined) {
+                        [paraIDDest, chainIDDest] = this.processDestV0X1(destV2Interior.x1, relayChain)
+                    } else if (destV1Interior.x2 !== undefined) {
+                        //if (this.debugLevel >= paraTool.debugErrorOnly) console.log(`potental error case destV1Interior.x2`, destV1Interior.x2)
+                        // dest for parachain, add 20000 for kusama-relay
+                        [paraIDDest, chainIDDest, _d] = this.processX2(destV2Interior.x2, relayChain)
+                    } else if (dest.v2.parents !== undefined && dest.v2.parents == 1 && destV1Interior != undefined && destV1Interior.here !== undefined) {
+                        paraIDDest = 0
+                        chainIDDest = paraTool.getChainIDFromParaIDAndRelayChain(0, relayChain)
+                    } else {
+                        //if (this.debugLevel >= paraTool.debugErrorOnly) console.log("dest v2 int unk = ", JSON.stringify(dest.v2.interior));
                         chainIDDest = false
                     }
                 }
@@ -3308,6 +3355,33 @@ module.exports = class ChainParser {
                             }
                             transferIndex++
                         }
+                    } else if (assets.v2 !== undefined && Array.isArray(assets.v2) && assets.v2.length > 0){
+                        // xcmV3 here
+                        if (this.debugLevel >= paraTool.debugErrorOnly) console.log(`[${extrinsic.extrinsicHash}] xcmV3 polkadotXcm assets.v2 case`)
+                        let assetsv1 = assets.v2
+                        let transferIndex = 0
+                        for (const asset of assetsv1) {
+                            // 0x2374aae493ae96e44954bcb4f242a049f2578d490bc382eae113fd5893dfd297
+                            // {"id":{"concrete":{"parents":0,"interior":{"here":null}}},"fun":{"fungible":10324356190528}}
+                            if (asset.fun !== undefined && asset.fun.fungible !== undefined) {
+                                let [targetedSymbol, targetedRelayChain, targetedXcmInteriorKey0] = this.processV1ConcreteFungible(indexer, asset)
+                                let targetedXcmInteriorKey = indexer.check_refintegrity_xcm_symbol(targetedSymbol, targetedRelayChain, chainID, chainIDDest, "processV1ConcreteFungible", `processOutgoingPolkadotXcm ${section_method}`, asset)
+                                console.log(`[${extrinsic.extrinsicHash}] ++ processV1ConcreteFungible targetedSymbol=${targetedSymbol}, targetedRelayChain=${targetedRelayChain}, targetedXcmInteriorKey=${targetedXcmInteriorKey}, targetedXcmInteriorKey0=${targetedXcmInteriorKey0}`)
+                                if (targetedXcmInteriorKey == false) targetedXcmInteriorKey = targetedXcmInteriorKey0
+                                let aa = {
+                                    xcmInteriorKey: targetedXcmInteriorKey,
+                                    xcmSymbol: targetedSymbol,
+                                    amountSent: paraTool.dechexToInt(asset.fun.fungible),
+                                    transferIndex: transferIndex,
+                                    isFeeItem: (transferIndex == feeAssetIndex) ? 1 : 0,
+                                }
+                                assetAndAmountSents.push(aa)
+                            } else {
+                                //if (this.debugLevel >= paraTool.debugErrorOnly) console.log("polkadotXcm asset v1 unknown", asset);
+                                asset = false;
+                            }
+                            transferIndex++
+                        }
                     }
                     for (const assetAndAmountSent of assetAndAmountSents) {
                         let targetedSymbol = assetAndAmountSent.xcmSymbol
@@ -3317,8 +3391,18 @@ module.exports = class ChainParser {
                         let isFeeItem = assetAndAmountSent.isFeeItem
                         let incomplete = this.extract_xcm_incomplete(extrinsic.events, extrinsic.extrinsicID);
                         if (assetAndAmountSent != undefined && paraTool.validAmount(amountSent) && (chainIDDest || chainIDDest == paraTool.chainIDPolkadot)) {
-                            if (extrinsic.xcms == undefined) extrinsic.xcms = []
+                            let msgHash =  '0x'
                             let xcmIndex = extrinsic.xcmIndex
+                            if (xcmMsgHashCandidates.length > 0){
+                                console.log(`xcmMsgHashCandidates ~~`, xcmMsgHashCandidates)
+                                if (xcmMsgHashCandidates.length - 1 >= xcmIndex && xcmMsgHashCandidates[xcmIndex] != undefined){
+                                    msgHash = xcmMsgHashCandidates[xcmIndex]
+                                    console.log(`Found xcmV3 ${feed.extrinsicHash} via event: msgHash`)
+                                }
+                            }
+
+                            if (extrinsic.xcms == undefined) extrinsic.xcms = []
+
                             let r = {
                                 sectionMethod: section_method,
                                 extrinsicHash: feed.extrinsicHash,


### PR DESCRIPTION
Xcmv3 Coverage :
* support for polkadotXcm v3, v2 -> msgHash available in events `parachainSystem(UpwardMessageSent)`, `xcmpQueue(XcmpMessageSent)`
* support for xcmPallet v3, v2 ->  msgHash continue to be missing

Test Cases:
* xcmPallet V3 https://polkaholic.io/tx/0x3a3da4e3887134be83edc92ff9ba55edd046efd17daba4f07a23c41cb80c0e52
* xcmPallet V2 https://polkaholic.io/tx/0x65665b149b349393e5aef0f4fb2df3828d93c42cadffcce32c5088868a7c7fcd

* polkadotXCM V2 https://polkaholic.io/tx/0xd207e90b6a1c4bc83ea12e99887cf8ce06d5c559f7228599890b6a1650683ddb
* polkadotXCM V3 https://polkaholic.io/tx/0xfb3abd627fda0eb4e758abdb4b8ebadd5d218bacd10315649f6cf905bdccf44c