### PR TITLE
Evm-Etl: processChainSteps refactoring

### DIFF
--- a/substrate/evm-etl
+++ b/substrate/evm-etl
@@ -279,11 +279,11 @@ async function main() {
     /* Regnerate One day worth of data
 
     Step0 create blocklog rec
-    Step1 ./evm-etl blcp -l 2023-05-12
+    Step1 ./evm-etl cpblk -l 2023-05-12
     Step2 ./evm-etl backfill -c 1 -l 2023-05-12
     Step3 ./evm-etl indexchain -c 1 -l 2023-05-12
-    Step4 ./evm-etl cpevmlogtogs -c 1 -l 2023-05-12
-    Step5 ./evm-etl loadevmrec -l 2023-05-12
+    Step4 ./evm-etl cpevmdecoded -c 1 -l 2023-05-12
+    Step5 ./evm-etl loadevmdecoded -l 2023-05-12
 
     */
 
@@ -294,7 +294,7 @@ async function main() {
         .option('-e, --endDT <endDT>', 'For multi-day ranges', null)
         .action(async (opt) => {
             var evmetl = new EVMETL();
-            let [prevDT, _c] = paraTool.ts_to_logDT_hr(evmetl.getCurrentTS() - 86400)
+            let [prevDT, _c] = paraTool.ts_to_logDT_hr(evmetl.getCurrentTS() - 86400 - 3600)
             let chainID = opt.chainID ? opt.chainID : paraTool.chainIDEthereum;
             let logDT = opt.logDT ? opt.logDT : prevDT;
             let endDT = opt.logDT && opt.endDT ? opt.endDT : null;
@@ -312,7 +312,7 @@ async function main() {
         });
 
 
-    program.command('blcp')
+    program.command('cpblk')
         .option('-c, --chainID <chainID>', 'ChainID to cpoy', myParseInt, paraTool.chainIDEthereum)
         .option('-l, --logDT <logDT>', 'Date', null)
         .option('-e, --endDT <endDT>', 'For multi-day ranges', null)
@@ -325,10 +325,10 @@ async function main() {
                 if (endDT) {
                     let logDTRange = evmetl.getLogDTRange(logDT, endDT)
                     for (const dt of logDTRange) {
-                        await evmetl.blcp(dt, chainID);
+                        await evmetl.cpblk(dt, chainID);
                     }
                 } else {
-                    await evmetl.blcp(logDT, chainID);
+                    await evmetl.cpblk(logDT, chainID);
                 }
             }
             process.exit(0);
@@ -378,13 +378,13 @@ async function main() {
             process.exit(0);
         });
 
-    program.command('cpevmlogtogs')
-        .option('-c, --chainID <chainID>', 'ChainID to Copy result into gs bucket: gs://evmrec/', myParseInt, paraTool.chainIDEthereum)
+    program.command('copyevmdecoded')
+        .option('-c, --chainID <chainID>', 'ChainID to Copy result into gs bucket: gs://evm_decoded/', myParseInt, paraTool.chainIDEthereum)
         .option('-l, --logDT <logDT>', 'Date', null)
         .option('-e, --endDT <endDT>', 'For multi-day ranges', null)
         .action(async (opt) => {
             var evmetl = new EVMETL();
-            let [prevDT, _c] = paraTool.ts_to_logDT_hr(evmetl.getCurrentTS() - 86400)
+            let [prevDT, _c] = paraTool.ts_to_logDT_hr(evmetl.getCurrentTS() - 86400 - 3600)
             let chainID = opt.chainID ? opt.chainID : paraTool.chainIDEthereum;
             let logDT = opt.logDT ? opt.logDT : prevDT;
             let endDT = opt.logDT && opt.endDT ? opt.endDT : null;
@@ -392,33 +392,33 @@ async function main() {
                 if (endDT) {
                     let logDTRange = evmetl.getLogDTRange(logDT, endDT)
                     for (const dt of logDTRange) {
-                        await evmetl.cp_evm_log_to_gs(dt, chainID);
+                        await evmetl.cpEvmDecodedToGS(dt, chainID);
                     }
                 } else {
-                    await evmetl.cp_evm_log_to_gs(logDT, chainID);
+                    await evmetl.cpEvmDecodedToGS(logDT, chainID);
                 }
             }
             process.exit(0);
         });
 
-    //loadevmrec cannot support chainID-specific update
-    program.command('loadevmrec')
+    //loadevmdecoded cannot support chainID-specific update
+    program.command('loadevmdecoded')
         //.option('-c, --chainID <chainID>', 'ChainID to load result', myParseInt, paraTool.chainIDEthereum)
         .option('-l, --logDT <logDT>', 'Date', null)
         .option('-e, --endDT <endDT>', 'For multi-day ranges', null)
         .action(async (opt) => {
             var evmetl = new EVMETL();
-            let [prevDT, _c] = paraTool.ts_to_logDT_hr(evmetl.getCurrentTS() - 86400)
+            let [prevDT, _c] = paraTool.ts_to_logDT_hr(evmetl.getCurrentTS() - 86400 - 3600)
             let logDT = opt.logDT ? opt.logDT : prevDT;
             let endDT = opt.logDT && opt.endDT ? opt.endDT : null;
             if (logDT) {
                 if (endDT) {
                     let logDTRange = evmetl.getLogDTRange(logDT, endDT)
                     for (const dt of logDTRange) {
-                        await evmetl.load_gs_evmrec(dt);
+                        await evmetl.loadGSEvmDecoded(dt);
                     }
                 } else {
-                    await evmetl.load_gs_evmrec(logDT);
+                    await evmetl.loadGSEvmDecoded(logDT);
                 }
             }
             process.exit(0);

--- a/substrate/evmetl.js
+++ b/substrate/evmetl.js
@@ -2030,7 +2030,7 @@ mysql> desc projectcontractabi;
         function: cpblk(dt, chainID)
 
     const step1_cpblk = 1
-        function: cpblk()
+        function: cpblk(dt, chainID)
         Source: crypto_ethereum..
         Output: gs://evm_etl/YYYY/MM/DD/chainID/
 
@@ -2092,21 +2092,25 @@ mysql> desc projectcontractabi;
         return jobInfo
     }
 
-    async cpblk(dt, chainID, id = "ethereum") {
-        let srcprojectID, srcdataset;
+    async cpblk(dt, chainID) {
+        let srcprojectID, srcdataset, id;
         let [logTS, logYYYYMMDD, currDT, prevDT, logYYYY_MM_DD] = this.getAllTimeFormat(dt)
-
         switch (chainID) {
-            case 1:
+            case paraTool.chainIDEthereum:
                 srcprojectID = "bigquery-public-data";
                 srcdataset = "crypto_ethereum";
                 id = 'ethereum';
                 break;
-            case 137:
+            case paraTool.chainIDPolygon:
                 srcprojectID = "public-data-finance";
                 srcdataset = "crypto_polygon";
                 id = 'polygon';
                 break;
+        }
+        let coveredChains = [paraTool.chainIDEthereum, paraTool.chainIDPolygon]
+        if (!coveredChains.includes(chainID)){
+            console.log(`[chainID=${chainID}, currDT=${currDT}] cpblk NOT READY`)
+            process.exit(1)
         }
         console.log(`chainID=${chainID}, srcprojectID=${srcprojectID}, srcdataset=${srcdataset}, uri=gs://evm_etl/${logYYYY_MM_DD}/${chainID}/`)
         let tables = {
@@ -2502,7 +2506,7 @@ mysql> desc projectcontractabi;
         return blocksInfo
     }
 
-    async backfill(dt, chainID, id = "ethereum") {
+    async backfill(dt, chainID) {
         let projectID = "substrate-etl";
         let dataset = null;
         switch (chainID) {

--- a/substrate/evmetl.js
+++ b/substrate/evmetl.js
@@ -2043,12 +2043,12 @@ mysql> desc projectcontractabi;
     const step3_indexEvmChain = 3
         function: index_evmchain(chainID, dt)
         Source: cbt evmchain${chainID}
-        LocalTmp: /tmp/evm_decoded/YYYY/MM/DD/
+        LocalTmp: /tmp/evm_decoded/YYYY/MM/DD/chainID/tableId*
 
     const STEP4_cpEvmDecodedToGS = 4
         function: cpEvmDecodedToGS(dt, chainID, dryrun)
-        Input: /tmp/evm_decoded/YYYY/MM/DD/
-        Output: gs://evm_decoded/YYYY/MM/DD/
+        Input: /tmp/evm_decoded/YYYY/MM/DD/chainID/tableId..
+        Output: gs://evm_decoded/YYYY/MM/DD/tableId../chainID.json
 
     const STEP5_loadGSEvmDecoded = 5
         function: loadGSEvmDecoded(dt, chainID)
@@ -2724,8 +2724,9 @@ mysql> desc projectcontractabi;
         //delete previously generated files for chainID
         let [logTS, logYYYYMMDD, currDT, prevDT, logYYYY_MM_DD] = this.getAllTimeFormat(logDT)
         let rootDir = '/tmp'
-        let evmDecodedBasePath = `${rootDir}/evm_decoded/${logYYYY_MM_DD}/`
-        await crawler.deleteFilesWithChainID(evmDecodedBasePath, chainID)
+        let evmDecodedBasePath = `${rootDir}/evm_decoded/${logYYYY_MM_DD}/${chainID}/`
+        //await crawler.deleteFilesWithChainID(evmDecodedBasePath, chainID)
+        await crawler.deleteFilesFromPath(evmDecodedBasePath)
 
         for (let bn = currPeriod.startBN; bn <= currPeriod.endBN; bn += jmp) {
             let startBN = bn
@@ -2826,7 +2827,7 @@ mysql> desc projectcontractabi;
         let [logTS, logYYYYMMDD, currDT, prevDT, logYYYY_MM_DD] = this.getAllTimeFormat(dt)
         //TODO: can't specify chainID and other filter here..
         let rootDir = '/tmp'
-        let cmd = `gsutil -m cp -r ${rootDir}/evm_decoded/${logYYYY_MM_DD}/* gs://evm_decoded/${logYYYY_MM_DD}/`
+        let cmd = `gsutil -m cp -r ${rootDir}/evm_decoded/${logYYYY_MM_DD}/${chainID}/* gs://evm_decoded/${logYYYY_MM_DD}/`
         console.log(cmd)
         let errCnt = 0
         if (!dryRun) {

--- a/substrate/indexer.js
+++ b/substrate/indexer.js
@@ -8458,7 +8458,8 @@ module.exports = class Indexer extends AssetManager {
         let blockTS = block.timestamp
         let [currDT, _c] = paraTool.ts_to_logDT_hr(blockTS)
         let logYYYY_MM_DD = currDT.replaceAll('-', '/')
-        let evmLogBasePath = `/disk1/evmlog/${logYYYY_MM_DD}/`
+        let rootDir = '/tmp'
+        let evmDecodedBasePath = `${rootDir}/evm_decoded/${logYYYY_MM_DD}/`
         let bqEvmBlock = {
             insertId: `${block.hash}`,
             json: {
@@ -8771,16 +8772,16 @@ module.exports = class Indexer extends AssetManager {
         let tableIds = Object.keys(auto_evm_rows_map)
         let autoEvmStorePromise = []
         let autoEvmStorePromiseFn = []
-        if (!fs.existsSync(evmLogBasePath)) {
-            fs.mkdirSync(evmLogBasePath, {
+        if (!fs.existsSync(evmDecodedBasePath)) {
+            fs.mkdirSync(evmDecodedBasePath, {
                 recursive: true
             });
-            console.log(`Making Directory "${evmLogBasePath}"`);
+            console.log(`Making Directory "${evmDecodedBasePath}"`);
         }
         for (const tableId of Object.keys(auto_evm_rows_map)) {
             let rows = auto_evm_rows_map[tableId]
             //call_buyWithETHWert_0x5173ffaa/1.json
-            let fn = `${evmLogBasePath}${tableId}/${chainID}.json`
+            let fn = `${evmDecodedBasePath}${tableId}/${chainID}.json`
             if (rows && rows.length > 0) {
                 let recs = []
                 for (const row of rows) {

--- a/substrate/indexer.js
+++ b/substrate/indexer.js
@@ -8358,6 +8358,16 @@ module.exports = class Indexer extends AssetManager {
 
         // Helper function to recursively search and delete files
         const searchAndDelete = (dirPath) => {
+            // Check if directory exists
+            if (!fs.existsSync(dirPath)) {
+                try {
+                    fs.mkdirSync(dirPath, { recursive: true });
+                    console.log(`Directory created: ${dirPath}`);
+                } catch (err) {
+                    console.error(`Error creating directory: ${dirPath}`, err);
+                }
+            }
+
             const entries = fs.readdirSync(dirPath, {
                 withFileTypes: true
             });
@@ -8370,14 +8380,6 @@ module.exports = class Indexer extends AssetManager {
                 }
             }
         };
-
-        // Create base path if it doesn't exist
-        if (!fs.existsSync(basePath)) {
-            fs.mkdirSync(basePath, {
-                recursive: true
-            });
-            console.log(`Created base path: ${basePath}`);
-        }
 
         // Start the search and delete process
         searchAndDelete(basePath);

--- a/substrate/indexer.js
+++ b/substrate/indexer.js
@@ -8459,7 +8459,7 @@ module.exports = class Indexer extends AssetManager {
         let [currDT, _c] = paraTool.ts_to_logDT_hr(blockTS)
         let logYYYY_MM_DD = currDT.replaceAll('-', '/')
         let rootDir = '/tmp'
-        let evmDecodedBasePath = `${rootDir}/evm_decoded/${logYYYY_MM_DD}/`
+        let evmDecodedBasePath = `${rootDir}/evm_decoded/${logYYYY_MM_DD}/${chainID}/`
         let bqEvmBlock = {
             insertId: `${block.hash}`,
             json: {

--- a/substrate/indexer.js
+++ b/substrate/indexer.js
@@ -8344,6 +8344,26 @@ module.exports = class Indexer extends AssetManager {
         return r;
     }
 
+    async deleteFilesFromPath(basePath) {
+        // Check if path exists
+        if (fs.existsSync(basePath)) {
+            try {
+                // Delete the directory and all its contents
+                fs.rmSync(basePath, { recursive: true, force: true });
+                console.log(`Path deleted: ${basePath}`);
+            } catch (err) {
+                console.error(`Error deleting path: ${basePath}`, err);
+            }
+        }
+        try {
+            // Create the directory
+            fs.mkdirSync(basePath, { recursive: true });
+            console.log(`Path created: ${basePath}`);
+        } catch (err) {
+            console.error(`Error creating path: ${basePath}`, err);
+        }
+    }
+
     async deleteFilesWithChainID(basePath, chainID) {
         // Helper function to delete a file
         console.log(`basePath: ${basePath}`)


### PR DESCRIPTION
Consistent naming convention across: local/gs. 
 
    const step0_createRec = 0
        function: cpblk(dt, chainID)

    const step1_cpblk = 1
        function: cpblk(dt, chainID)
        Source: crypto_ethereum..
        Output: gs://evm_etl/YYYY/MM/DD/chainID/

    const step2_backfill = 2
        function: backfill(dt, chainID)
        Source: gs://evm_etl/YYYY/MM/DD/chainID/
        LocalTmp: /tmp/evm_etl/YYYY/MM/DD/chainID/
        Output: cbt evmchain${chainID}

    const step3_indexEvmChain = 3
        function: index_evmchain(chainID, dt)
        Source: cbt evmchain${chainID}
        LocalTmp: /tmp/evm_decoded/YYYY/MM/DD/chainID/tableId*

    const STEP4_cpEvmDecodedToGS = 4
        function: cpEvmDecodedToGS(dt, chainID, dryrun)
        Input: /tmp/evm_decoded/YYYY/MM/DD/chainID/tableId..
        Output: gs://evm_decoded/YYYY/MM/DD/tableId../chainID.json

    const STEP5_loadGSEvmDecoded = 5
        function: loadGSEvmDecoded(dt, chainID)
        Input:gs://evm_decoded/YYYY/MM/DD/
        localInput: /disk1/evmschema

*NOTE*:  local indexing must use /YYYY/MM/DD/chainID/ to prevent concurrent indexing issues
